### PR TITLE
chore(project): shorten imports and add missing exports

### DIFF
--- a/src/Library/Config/ModuleManagerConfigInterface.ts
+++ b/src/Library/Config/ModuleManagerConfigInterface.ts
@@ -1,4 +1,4 @@
-import { ModuleClassInterface } from '../ModuleManager/ModuleClassInterface';
+import { ModuleClassInterface } from '../ModuleManager';
 
 export interface ModuleManagerConfigInterface extends Array<ModuleClassInterface> {
 }

--- a/src/Library/Config/RouterConfigInterface.ts
+++ b/src/Library/Config/RouterConfigInterface.ts
@@ -1,4 +1,4 @@
-import { RouteInterface } from '../Router/RouteInterface';
+import { RouteInterface } from '../Router';
 
 export interface RouterConfigInterface {
   routes: Array<RouteInterface>;

--- a/src/Library/Config/ServerConfigInterface.ts
+++ b/src/Library/Config/ServerConfigInterface.ts
@@ -1,11 +1,8 @@
-import { Middleware } from 'koa';
 import cors from 'koa__cors';
-import { Application } from '../Application';
 
 export interface ServerConfigInterface {
-  boostrap?: Function;
+  bootstrap?: Function;
   port?: number;
-  middlewares?: Array<(application: Application) => Middleware>;
   cors?: {
     enabled?: boolean;
     options?: cors.Options;

--- a/src/Library/Response/ClientErrorResponse.ts
+++ b/src/Library/Response/ClientErrorResponse.ts
@@ -1,4 +1,4 @@
-import { HttpStatusCodes } from '../Server/HttpStatusCodes';
+import { HttpStatusCodes } from '../Server';
 import { Response } from './Response';
 
 export class ClientErrorResponse extends Response {

--- a/src/Library/Response/InformationalResponse.ts
+++ b/src/Library/Response/InformationalResponse.ts
@@ -1,4 +1,4 @@
-import { HttpStatusCodes } from '../Server/HttpStatusCodes';
+import { HttpStatusCodes } from '../Server';
 import { Response } from './Response';
 
 export class InformationalResponse extends Response {

--- a/src/Library/Response/RedirectionResponse.ts
+++ b/src/Library/Response/RedirectionResponse.ts
@@ -1,4 +1,4 @@
-import { HttpStatusCodes } from '../Server/HttpStatusCodes';
+import { HttpStatusCodes } from '../Server';
 import { Response } from './Response';
 
 export class RedirectionResponse extends Response {

--- a/src/Library/Response/Response.ts
+++ b/src/Library/Response/Response.ts
@@ -1,4 +1,4 @@
-import { HttpStatusCodes } from '../Server/HttpStatusCodes';
+import { HttpStatusCodes } from '../Server';
 import { ContextInterface } from '../Interface';
 
 export abstract class Response {

--- a/src/Library/Response/ResponseManager.ts
+++ b/src/Library/Response/ResponseManager.ts
@@ -1,4 +1,4 @@
-import { ResponseConfigInterface } from '../Config/ResponseConfigInterface';
+import { ResponseConfigInterface } from '../Config';
 import { InformationalResponse } from './InformationalResponse';
 import { RedirectionResponse } from './RedirectionResponse';
 import { ServerErrorResponse } from './ServerErrorResponse';

--- a/src/Library/Response/ServerErrorResponse.ts
+++ b/src/Library/Response/ServerErrorResponse.ts
@@ -1,4 +1,4 @@
-import { HttpStatusCodes } from '../Server/HttpStatusCodes';
+import { HttpStatusCodes } from '../Server';
 import { Response } from './Response';
 
 export class ServerErrorResponse extends Response {

--- a/src/Library/Response/SuccessfulResponse.ts
+++ b/src/Library/Response/SuccessfulResponse.ts
@@ -1,4 +1,4 @@
-import { HttpStatusCodes } from '../Server/HttpStatusCodes';
+import { HttpStatusCodes } from '../Server';
 import { Response } from './Response';
 
 export class SuccessfulResponse extends Response {

--- a/src/Library/Router/RegisteredRouteInterface.ts
+++ b/src/Library/Router/RegisteredRouteInterface.ts
@@ -1,4 +1,4 @@
-import { RequestMethods } from '../Server/RequestMethods';
+import { RequestMethods } from '../Server';
 import { Key } from 'path-to-regexp';
 
 export interface RegisteredRouteInterface {

--- a/src/Library/Router/Route.ts
+++ b/src/Library/Router/Route.ts
@@ -1,4 +1,4 @@
-import { RequestMethods } from '../Server/RequestMethods';
+import { RequestMethods } from '../Server';
 
 export class Route {
   public static method(method: string, route: string, controller: string | { new() : Object }, action: string): {} {

--- a/src/Library/Router/RouteInterface.ts
+++ b/src/Library/Router/RouteInterface.ts
@@ -1,4 +1,4 @@
-import { RequestMethods } from '../Server/RequestMethods';
+import { RequestMethods } from '../Server';
 
 export interface RouteInterface {
   method: RequestMethods;

--- a/src/Library/Router/Router.ts
+++ b/src/Library/Router/Router.ts
@@ -1,8 +1,8 @@
 import pathToRegexp, { Key } from 'path-to-regexp';
-import { RequestMethods } from '../Server/RequestMethods';
+import { RequestMethods } from '../Server';
 import { RegisteredRouteInterface } from './RegisteredRouteInterface';
 import { RouteInterface } from './RouteInterface';
-import { RouterConfigInterface } from '../Config/RouterConfigInterface';
+import { RouterConfigInterface } from '../Config';
 
 export class Router {
   private routes:Array<RegisteredRouteInterface> = [];

--- a/src/Library/Router/index.ts
+++ b/src/Library/Router/index.ts
@@ -1,1 +1,4 @@
 export * from './Router';
+export * from './RegisteredRouteInterface';
+export * from './RouteInterface';
+export * from './Route';

--- a/src/Library/Server/index.ts
+++ b/src/Library/Server/index.ts
@@ -1,2 +1,3 @@
 export * from './Server';
 export * from './HttpStatusCodes';
+export * from './RequestMethods';

--- a/src/middleware/request.ts
+++ b/src/middleware/request.ts
@@ -1,7 +1,7 @@
 import bytes from 'bytes';
 import { Middleware } from 'koa';
 import { ContextInterface, Response } from '../Library';
-import { RequestMethods } from '../Library/Server/RequestMethods';
+import { RequestMethods } from '../Library/Server';
 import createDebugLogger from '../debug';
 
 const debug = createDebugLogger('middleware:request');

--- a/src/middleware/router.ts
+++ b/src/middleware/router.ts
@@ -1,6 +1,6 @@
 import { Middleware } from 'koa';
 import { ContextInterface, ControllerManager, Application } from '../Library';
-import { RequestMethods } from '../Library/Server/RequestMethods';
+import { RequestMethods } from '../Library/Server';
 import createDebugLogger from '../debug';
 
 const debug = createDebugLogger('middleware:router');


### PR DESCRIPTION
I thought it would be nicer to keep the imports short like that. If it was unnecessary you don't need to merge, I can make another PR with the `export`s only.