### PR TITLE
chore(project): readonly properties

### DIFF
--- a/src/Library/Application/Application.ts
+++ b/src/Library/Application/Application.ts
@@ -20,7 +20,7 @@ import {
 const debug = createDebugLogger('application');
 
 export class Application {
-  private config: Config;
+  private readonly config: Config;
 
   private logger: winston.Logger;
 

--- a/src/Library/ModuleManager/ModuleManager.ts
+++ b/src/Library/ModuleManager/ModuleManager.ts
@@ -6,9 +6,9 @@ import createDebugLogger from '../../debug';
 const debug = createDebugLogger('modules');
 
 export class ModuleManager {
-  private application: Application;
+  private readonly application: Application;
 
-  private config: ModuleManagerConfigInterface;
+  private readonly config: ModuleManagerConfigInterface;
 
   constructor(application: Application, config: ModuleManagerConfigInterface) {
     this.application = application;

--- a/src/Library/Server/Server.ts
+++ b/src/Library/Server/Server.ts
@@ -12,9 +12,9 @@ export const DEFAULT_PORT: number = 1991;
 export class Server {
   private server: Koa;
 
-  private config: ServerConfigInterface;
+  private readonly config: ServerConfigInterface;
 
-  private application: Application;
+  private readonly application: Application;
 
   constructor (application: Application, config: ServerConfigInterface = {}) {
     this.application = application;


### PR DESCRIPTION
I've turned the `config` and `application` properties into readonly.
I see no reason to let them be reassignable.