### PR TITLE
chore(Response): make the constructor protected

### DIFF
--- a/src/Library/Response/Response.ts
+++ b/src/Library/Response/Response.ts
@@ -16,7 +16,7 @@ export abstract class Response {
 
   protected message: string;
 
-  constructor ({ message, data, meta, statusCode }: ResponseArgumentsInterface) {
+  protected constructor ({ message, data, meta, statusCode }: ResponseArgumentsInterface) {
     this.data       = data;
     this.meta       = meta;
     this.message    = message;


### PR DESCRIPTION
I've made a different PR for this commit because I don't know if it _should_ be like this, but I think it is good that we can't instantiate a new `Response` since this class is just a parent and parents don't know anything. You know my mom.

Do you agree with me or using `Response` should be an option?